### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/xbanner/src/main/AndroidManifest.xml
+++ b/xbanner/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application
         android:allowBackup="true"
-        android:label="@string/app_name"
+       
         android:supportsRtl="true">
     </application>
 


### PR DESCRIPTION
Error:Execution failed for task ':app:processCheckDebugManifest'.
> Manifest merger failed : Attribute application@label value=(测-WalleDemo) from AndroidManifest.xml:8:9-36
  	is also present at [com.xhb:xbanner:1.3.1] AndroidManifest.xml:11:9-41 value=(@string/app_name).
  	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:5:5-18:19 to override.